### PR TITLE
style(): updating to use a simplified approach to CSS and making it m…

### DIFF
--- a/apps/example-app/src/app/home/components/app-content/app-content.component.html
+++ b/apps/example-app/src/app/home/components/app-content/app-content.component.html
@@ -11,17 +11,9 @@
         </ion-card-header>
         <ion-card-content>
             Toggle the sizes on the left to see how they respond
-            <ion-button>Example Button </ion-button>
+            <ion-button> Example Button </ion-button>
         </ion-card-content>
     </ion-card>
-    <section class="scrolling-cards">
-        <ion-card>
-            <img alt="Silhouette of mountains" src="https://ionicframework.com/docs/img/demos/card-media.png" />
-            <ion-card-header>
-                <ion-card-title>Test Card Title</ion-card-title>
-            </ion-card-header>
-        </ion-card>
-    </section>
     <section class="footer">
         <ion-tabs>
             <ion-tab-bar slot="bottom">

--- a/apps/example-app/src/app/home/components/app-content/app-content.component.scss
+++ b/apps/example-app/src/app/home/components/app-content/app-content.component.scss
@@ -1,18 +1,10 @@
-:root {
-    /* CSS Variables for each module */
-    /* This are called global scope variables */
-    --header-module-font-size: 1.2rem;
-    --section-module-font-size: 1rem;
-    --cards-components-font-size: 1rem;
-    --footer-module-font-size: 0.75rem;
-}
-/* Header Module */
 ion-header {
     display: flex;
     align-items: center;
     justify-content: center;
     color: white;
     background-color: #0c699e;
+    border-radius: 2rem 2rem 0 0;
     /* This height and width are relatives to the Phone Module */
     height: 7.5%;
     width: 100%;
@@ -39,43 +31,36 @@ ion-card {
     /* Ion Cards needs the font size directly here, the content module font size change not apply here */
     font-size: var(--cards-components-font-size);
 }
-ion-card.openforge-card {
-    --background: var(--openforge-orange);
 
+.openforge-card {
+    --background: var(--openforge-orange);
     color: white;
 }
-ion-card.openforge-card ion-button {
-    --background: #00cccc;
 
-    width: 60%;
+ion-button {
+    --background: #00cccc;
+    font-size: 0.8rem;
 }
-ion-card ion-card-title {
+
+ion-card-title {
     font-size: 1.2em;
 }
-ion-card ion-card-subtitle {
-    font-size: 1em;
-}
-ion-card ion-card-content {
+
+ion-card-content {
     font-size: 1.1em;
 }
-ion-content .scrolling-cards {
-    display: flex;
-    /* This height and width are relatives to the viewport */
-    width: 100vw;
-    max-width: 100vw;
-    overflow-x: scroll;
-}
-ion-content .scrolling-cards ion-card {
-    /* This height and width are relatives to the Parent */
-    width: 10%;
-}
-/* Footer Module */
-ion-content section.footer {
+
+.footer {
     /* This font size will scale with document */
     /* If we change this one manually only will impact in the Footer module */
     font-size: var(--footer-module-font-size);
     ion-tab-button {
         /* This font size will scale with Footer module */
-        font-size: 0.8em;
+        font-size: 1rem;
+        border-radius: 0 0 2rem 2rem;
     }
+    ion-tab-bar {
+        border-radius: 0 0 2rem 2rem;
+    }
+    border-radius: 0 0 2rem 2rem;
 }

--- a/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.html
+++ b/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.html
@@ -1,5 +1,4 @@
-<section class="phone">
-  <div class="phone-wrapper">
+<!-- LAYOUT FOR Default Phone Selected-->
+<div class="phone-wrapper">
     <ng-content></ng-content>
-  </div>
-</section>
+</div>

--- a/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.scss
+++ b/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.scss
@@ -1,26 +1,8 @@
-/* Phone Module */
-section.phone {
-    /* CSS Variables for device size */
-    /* Needs to be set here in order to apply the % to the right module */
-    /* If we set this properties at the top with the other ones, the % will apply to the full viewport instead the module */
-    /* This are called local scope variables */
-    --device-height: 70vh;
-    --device-width: 15vw;
-    /* This height and width are relatives to the viewport */
-    right: 22vw;
-    top: 14vh;
-    z-index: 2;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    position: absolute;
-}
-div.phone-wrapper {
+.phone-wrapper {
     /* This height and width are relatives to the Phone Module */
-    height: var(--device-height);
-    width: var(--device-width);
-    border-radius: 40px;
+    height: 100%; // of parent, in this case on home.pgae
+    width: 15vw; // of parent, in this case on home.page
+    border-radius: 2rem;
     border: 4px solid #31393e;
-    overflow: hidden;
     box-shadow: inset 0 0 40px 5px rgba(255, 255, 255, 0.2);
 }

--- a/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.ts
+++ b/apps/example-app/src/app/home/components/default-phone-layout/default-phone-layout.component.ts
@@ -1,5 +1,8 @@
 import { Component } from '@angular/core';
 
+/**
+ * * Component used to show content in a phone view
+ */
 @Component({
     selector: 'openforge-default-phone-layout',
     templateUrl: 'default-phone-layout.component.html',

--- a/apps/example-app/src/app/home/components/devices-popover/devices-popover.component.html
+++ b/apps/example-app/src/app/home/components/devices-popover/devices-popover.component.html
@@ -1,5 +1,5 @@
 <ion-list>
-  <ion-item lines="none" (click)="selectDevice('Default Phone')">Default Phone</ion-item>
-  <ion-item lines="none" (click)="selectDevice('iPhone 6')">Iphone 6</ion-item>
-  <ion-item lines="none" (click)="selectDevice('iPhone X')">Iphone X</ion-item>
+    <ion-item lines="none" (click)="selectDevice('Default Phone Selected')">Default Phone Selected</ion-item>
+    <ion-item lines="none" (click)="selectDevice('iPhone 6')">Iphone 6</ion-item>
+    <ion-item lines="none" (click)="selectDevice('iPhone X')">Iphone X</ion-item>
 </ion-list>

--- a/apps/example-app/src/app/home/components/iphone-layout/iphone-layout.component.scss
+++ b/apps/example-app/src/app/home/components/iphone-layout/iphone-layout.component.scss
@@ -14,7 +14,8 @@ section {
     justify-content: flex-end;
     z-index: 2;
 }
-div.iphone {
+
+.iphone {
     /* This height and width are the Phone Module */
     height: var(--device-height);
     width: var(--device-width);
@@ -27,7 +28,8 @@ div.iphone {
     border-radius: 30px;
     box-shadow: 0 3px 5px 0 rgb(50 50 50 / 25%);
 }
-div.iphone-inner {
+
+.iphone-inner {
     /* This height and width are relatives to the Phone Module */
     width: 100%;
     height: 100%;

--- a/apps/example-app/src/app/home/home.page.html
+++ b/apps/example-app/src/app/home/home.page.html
@@ -1,29 +1,48 @@
-<section>
-    <section class="sliders">
-        <div class="sliders-wrappers">
-            <div class="sliders-zone">
-                <p><ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Document')"></ion-icon> Document Module</p>
-                <ion-range min="10" max="20" step="1" value="16" (ionChange)="documentModuleValueChange($event.detail.value)"> </ion-range>
-                <p><ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Header')"></ion-icon> Header Module</p>
-                <ion-range min="0.6" max="1.2" step="0.2" value="1.2" (ionChange)="headerModuleValueChange($event.detail.value)"> </ion-range>
-                <p><ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Content')"></ion-icon> Content Module</p>
-                <ion-range min="0.6" max="2.0" step="0.2" value="1" (ionChange)="sectionModuleValueChange($event.detail.value)"> </ion-range>
-                <p><ion-icon name="information-circle-outline" value="'Footer Module Modifier'" (click)="presentTooltip($event, 'Footer')"></ion-icon> Footer Module</p>
-                <ion-range min="0.5" max="1.0" step="0.05" value="0.75" (ionChange)="footerModuleValueChange($event.detail.value)"> </ion-range>
-                <ion-button id="click-trigger" (click)="presentPopover($event)">
-                    {{ devicePhoneSelected }}
-                </ion-button>
-            </div>
-        </div>
-    </section>
-    <!-- DISPLAY THE PHONE AND PHONE CONTENT-->
-    <openforge-default-phone-layout *ngIf="devicePhoneSelected === 'Default Phone'">
-        <openforge-app-content></openforge-app-content>
-    </openforge-default-phone-layout>
-    <openforge-iphone-layout *ngIf="devicePhoneSelected === 'iPhone 6'">
-        <openforge-app-content></openforge-app-content>
-    </openforge-iphone-layout>
-    <openforge-iphone-x-layout *ngIf="devicePhoneSelected === 'iPhone X'">
-        <openforge-app-content></openforge-app-content>
-    </openforge-iphone-x-layout>
-</section>
+<div class="flex-container">
+    <div class="left-column">
+        <p>
+            <ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Document')"></ion-icon>
+            Document Root<br />
+            <i>Font-size: {{ rootFontSize }}px</i>
+            <ion-range min="10" max="20" step="1" value="16" (ionChange)="documentModuleValueChange($event.detail.value)"> </ion-range>
+        </p>
+
+        <p>
+            <ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Header')"></ion-icon>
+            Header Module: <br />
+            <i>{{ headerRem | number: '1.2-2' }}rem = {{ headerRem * rootFontSize | number: '1.2-2' }}px</i>
+            <ion-range min="0.6" max="1.6" step="0.2" value="1" (ionChange)="headerModuleValueChange($event.detail.value)"> </ion-range>
+        </p>
+
+        <p>
+            <ion-icon name="information-circle-outline" (click)="presentTooltip($event, 'Content')"></ion-icon>
+            Content Module: <br />
+            <i>{{ contentRem | number: '1.2-2' }}rem = {{ contentRem * rootFontSize | number: '1.2-2' }}px</i>
+            <ion-range min="0.6" max="2.0" step="0.2" value="1" (ionChange)="contentModuleValueChange($event.detail.value)"> </ion-range>
+        </p>
+
+        <p>
+            <ion-icon name="information-circle-outline" value="'Footer Module Modifier'" (click)="presentTooltip($event, 'Footer')"></ion-icon>
+            Footer Module: <br />
+            <i>{{ footerRem | number: '1.2-2' }}rem = {{ footerRem * rootFontSize | number: '1.2-2' }}px</i>
+            <ion-range min="0.5" max="1.6" step="0.2" value="1" (ionChange)="footerModuleValueChange($event.detail.value)"> </ion-range>
+        </p>
+
+        <!-- ALLOWS USER TO SELECT PHONE-->
+        <ion-button id="click-trigger" (click)="presentPopover($event)">
+            {{ devicePhoneSelected }}
+        </ion-button>
+    </div>
+    <div class="right-column">
+        <!-- DISPLAY THE PHONE AND PHONE CONTENT-->
+        <openforge-default-phone-layout *ngIf="devicePhoneSelected === 'Default Phone Selected'">
+            <openforge-app-content></openforge-app-content>
+        </openforge-default-phone-layout>
+        <openforge-iphone-layout *ngIf="devicePhoneSelected === 'iPhone 6'">
+            <openforge-app-content></openforge-app-content>
+        </openforge-iphone-layout>
+        <openforge-iphone-x-layout *ngIf="devicePhoneSelected === 'iPhone X'">
+            <openforge-app-content></openforge-app-content>
+        </openforge-iphone-x-layout>
+    </div>
+</div>

--- a/apps/example-app/src/app/home/home.page.scss
+++ b/apps/example-app/src/app/home/home.page.scss
@@ -1,72 +1,59 @@
 p {
-    margin: 0;
+    margin: 0; // removes spacing between document module and sliders
+    font-size: 0.8rem;
 }
-/* Main Section */
-section {
-    background-color: #f4f6f9;
-}
-/* Sliders Module */
-section.sliders {
+
+.flex-container {
     /* This height and width are relatives to the viewport */
-    height: 100vh;
+    display: flex;
+    height: 50vh;
     width: 50vw;
+    /* The margins center the content */
+    margin-left: 25vw;
+    margin-right: 25vw;
+    margin-top: 25vh;
+    margin-bottom: 25vh;
+    background-color: white;
+}
+
+.right-column {
+    background-color: white;
+}
+
+.left-column {
+    width: 40%; // of parent (flex-container)
+    padding: 1rem;
+    margin: 1rem;
+    box-shadow: 0 0.5rem 0.8rem -0.4rem rgba(0, 0, 0, 0.75);
     display: flex;
     flex-direction: column;
     position: relative;
     align-items: center;
     justify-content: center;
-    margin: auto;
     p {
-        /* This font size is overriding the variable in order to not be modified when updating the document font size
-        since this text is not needed to be responsive
+        /* Since the sliders affect root font-size, that also affects this component.
+        So lets override font-size here manually so that the slider font size stays the same.
         */
-        /* Since we want the text on the sliders section not be modified we need to disable the stylelint to be able to use px */
         /* stylelint-disable */
         font-size: 16px;
         /* stylelint-enable */
-        color: black;
     }
 }
+
 ion-icon {
     font-size: 1.25rem;
     vertical-align: middle;
 }
 
-div.sliders-wrappers {
-    /* This height and width are relatives to the Sliders Module */
-    width: 100%;
-    background-color: white;
-    padding: 1rem;
-    margin: 1rem;
-    box-shadow: 0 6px 10px -5px rgba(0, 0, 0, 0.75);
-}
-
-div.sliders-zone {
-    /* This height and width are relatives to the Parent */
-    height: 100%;
-    width: 50%;
-}
-div.device-header {
-    width: 100%;
-    padding-right: 1rem;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    display: flex;
-    justify-content: start;
-
-    p {
-        font-weight: bold;
-        font-size: 1.25rem;
-    }
-}
 ion-range {
     --bar-background: var(--openforge-orange-lighter-25);
     --bar-background-active: var(--openforge-orange);
-
     padding-left: 0;
     padding-right: 0;
 }
+
 ion-button {
     --background: var(--openforge-orange);
+    font-size: 1rem;
     width: 100%;
 }

--- a/apps/example-app/src/app/home/home.page.ts
+++ b/apps/example-app/src/app/home/home.page.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import { Component } from '@angular/core';
 import { PopoverController } from '@ionic/angular';
 
@@ -5,34 +6,42 @@ import { DevicesPopoverComponent } from './components/devices-popover/devices-po
 import { TooltipComponent } from './tooltip.component';
 
 @Component({
-    // eslint-disable-next-line @angular-eslint/component-selector
-    selector: 'app-home',
+    selector: 'openforge-home',
     templateUrl: 'home.page.html',
     styleUrls: ['home.page.scss'],
 })
 export class HomePageComponent {
-    public devicePhoneSelected = 'Default Phone';
+    public devicePhoneSelected = 'Default Phone Selected'; // * the type of phone
+    public rootFontSize = 16; // defaults to 16
+    public headerRem = 1; // defaults to 1rem
+    public contentRem = 1; // defaults to 1rem
+    public footerRem = 1; // defaults to 1rem
 
-    // eslint-disable-next-line no-empty-function
-    public constructor(public popoverController: PopoverController) {}
+    public constructor(public popoverController: PopoverController) {
+        console.log('home.page.ts', 'constructor()');
+    }
 
     public documentModuleValueChange(value: string): void {
+        this.rootFontSize = value as unknown as number;
         document.documentElement.style.setProperty('--document-font-size', `${value}px`);
         document.documentElement.style.setProperty('--document-font-size-900', `${+value - 3}px`);
         document.documentElement.style.setProperty('--document-font-size-400', `${+value - 6}px`);
     }
 
     public headerModuleValueChange(value: string): void {
+        this.headerRem = value as unknown as number;
         document.documentElement.style.setProperty('--header-module-font-size', `${value}rem`);
     }
 
-    public footerModuleValueChange(value: string): void {
-        document.documentElement.style.setProperty('--footer-module-font-size', `${value}rem`);
-    }
-
-    public sectionModuleValueChange(value: string): void {
+    public contentModuleValueChange(value: string): void {
+        this.contentRem = value as unknown as number;
         document.documentElement.style.setProperty('--section-module-font-size', `${value}rem`);
         document.documentElement.style.setProperty('--cards-components-font-size', `${value}rem`);
+    }
+
+    public footerModuleValueChange(value: string): void {
+        this.footerRem = value as unknown as number;
+        document.documentElement.style.setProperty('--footer-module-font-size', `${value}rem`);
     }
 
     /*
@@ -46,11 +55,11 @@ export class HomePageComponent {
             case 'Document':
                 tooltipText = 'Modifies the px value for font sizes used on the document. Affects the contents used throughout the whole document.';
                 break;
-            case 'Header':
-                tooltipText = 'Modifies the rem value of the header font size';
-                break;
             case 'Content':
                 tooltipText = 'Modifies the rem value for all items inside of the content tag.';
+                break;
+            case 'Header':
+                tooltipText = 'Modifies the rem value of the header font size';
                 break;
             case 'Footer':
                 tooltipText = 'Modifies the rem value of the footer font size';

--- a/apps/example-app/src/global.scss
+++ b/apps/example-app/src/global.scss
@@ -30,6 +30,12 @@ Is to be the ONLY place for media queries.
     --document-font-size: 16px;
     --document-font-size-900: 13px;
     --document-font-size-400: 10px;
+    /* CSS Variables for each module */
+    /* This are called global scope variables */
+    --header-module-font-size: 1.2rem;
+    --section-module-font-size: 1rem;
+    --cards-components-font-size: 1rem;
+    --footer-module-font-size: 0.75rem;
     --openforge-orange: #e78112;
     --openforge-orange-lighter-25: #f19f47;
 }


### PR DESCRIPTION
- Removed unnecessary code and child selectors so that we have less to write and less to maintain
- Moved root declarations to the global.scss
- added explanation in terms of calculated rem and the document size so user can see live what they're editing
- Made the entire app module responsive to the actual view height/view width so we don't run into issues on smaller screens

NOTE: 

Did not change the iphone layout and iphone-x layout, going to pass to @Fdom92 and @Nachzz to tackle tomorrow:
1. [Refactor(): Refactor the iphone-x-layout component to match the default-phone-layout, specifically..](https://openforge.teamwork.com/#/tasks/27974513)
2. [Refactor(): Refactor the iphone-layout component to match the default-phone-layout, specifically..](https://openforge.teamwork.com/#/tasks/27974514)

![Screen Shot 2022-12-11 at 3 53 50 PM](https://user-images.githubusercontent.com/996175/206928237-c6f3ce94-c1fd-4104-9d69-9ad23582cbb4.png)

# Pull request type

-   [x] Bugfix
-   [x] Feature
-   [x] Code style update (formatting, renaming)
-   [x] Refactoring (no functional changes, no api changes)

# What is the current behavior?
![Screen Shot 2022-12-11 at 4 01 06 PM](https://user-images.githubusercontent.com/996175/206928534-677ef4aa-7467-4ae9-a062-2472d0253f83.png)

# What is the new behavior?

![Screen Shot 2022-12-11 at 3 53 50 PM](https://user-images.githubusercontent.com/996175/206928237-c6f3ce94-c1fd-4104-9d69-9ad23582cbb4.png)

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

# Other information
